### PR TITLE
My latest additions

### DIFF
--- a/Resources/lib/sc_ti.js
+++ b/Resources/lib/sc_ti.js
@@ -86,6 +86,24 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
     }
   };
   
+  SCTi.Focusable = {
+    tiEvents: 'focus:focused blur:blurred'.w(),
+    
+    blur: function() {
+      this.render();
+      get(this, 'tiObject').blur();
+
+      return this;
+    },
+    
+    focus: function() {
+      this.render();
+      get(this, 'tiObject').focus();
+
+      return this;
+    }
+  };
+  
   // SproutCore Wrapped Titanium Objects
   SCTi.Object = SC.Object.extend({
     tiObject: null,
@@ -298,9 +316,9 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
     }
   });
   
-  SCTi.TextField = SCTi.View.extend({
+  SCTi.TextField = SCTi.View.extend(SCTi.Focusable, {
     tiOptions: 'autocapitalization:autocapitalizationConstant borderStyle:borderStyleConstant clearButtonMode:clearButtonModeConstant clearOnEdit editable enabled hintText keyboardToolbar keyboardToolbarColor keyboardToolbarHeight keyboardType:keyboardTypeConstant leftButton leftButtonMode leftButtonPadding minimumFontSize paddingLeft paddingRight returnKeyType:returnKeyTypeConstant rightButton rightButtonMode rightButtonPadding suppressReturn value verticalAlign:verticalAlignConstant'.w(),
-    tiEvents: 'focus blur change hasText return'.w(),
+    tiEvents: 'change hasText return'.w(),
     tiConstantMappings: {
       autocapitalization: SCTi.AUTOCAPITALIZATION_CONSTANTS,
       borderStyle: {
@@ -398,9 +416,9 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
     }
   });
 
-  SCTi.TextArea = SCTi.View.extend({
+  SCTi.TextArea = SCTi.View.extend(SCTi.Focusable, {
     tiOptions: 'autoLink autocapitalization:autocapitalizationConstant editable enabled keyboardToolbar keyboardToolbarColor keyboardToolbarHeight returnKeyType:returnKeyTypeConstant suppressReturn value'.w(),
-    tiEvents: 'blur change focus return selected'.w(),
+    tiEvents: 'change return selected'.w(),
     tiConstantMappings: {
       autocapitalization: SCTi.AUTOCAPITALIZATION_CONSTANTS,
       keyboardType: SCTi.KEYBOARD_TYPE_CONSTANTS,

--- a/Resources/lib/sc_ti.js
+++ b/Resources/lib/sc_ti.js
@@ -268,6 +268,12 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
     add: function(view) {
       var childViews = get(this, 'childViews');
       childViews.push(view);
+      
+      if (get(this, 'isRendered')) {
+        view.render();
+        this.addChildView(get(this, 'tiObject'), view);
+      }
+      
       return this;
     },
     

--- a/Resources/lib/sc_ti.js
+++ b/Resources/lib/sc_ti.js
@@ -44,7 +44,7 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
   };
   
   // Mixins
-  SCTi.Animatable = {
+  SCTi.Animatable = SC.Mixin.create({
     animate: function(scAnimation) {
       this.render();
       scAnimation.render();
@@ -52,9 +52,9 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
       
       return this;
     }
-  };
+  });
   
-  SCTi.Openable = {
+  SCTi.Openable = SC.Mixin.create({
     open: function(options) {
       this.render();
       get(this, 'tiObject').open(options);
@@ -68,9 +68,9 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
       
       return this;
     }
-  };
+  });
   
-  SCTi.Hideable = {
+  SCTi.Hideable = SC.Mixin.create({
     hide: function() {
       this.render();
       get(this, 'tiObject').hide();
@@ -84,9 +84,9 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
       
       return this;
     }
-  };
+  });
   
-  SCTi.Focusable = {
+  SCTi.Focusable = SC.Mixin.create({
     tiEvents: 'focus:focused blur:blurred'.w(),
     
     blur: function() {
@@ -102,7 +102,7 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
 
       return this;
     }
-  };
+  });
   
   // SproutCore Wrapped Titanium Objects
   SCTi.Object = SC.Object.extend({

--- a/Resources/lib/sc_ti.js
+++ b/Resources/lib/sc_ti.js
@@ -55,9 +55,9 @@ queues.insertAt(queues.indexOf('actions')+1, 'render');
   };
   
   SCTi.Openable = {
-    open: function() {
+    open: function(options) {
       this.render();
-      get(this, 'tiObject').open();
+      get(this, 'tiObject').open(options);
       
       return this;
     },

--- a/Resources/tests/mixins.js
+++ b/Resources/tests/mixins.js
@@ -73,4 +73,34 @@
       expect(wasCalled).toEqual(true);
     });
   });
+  
+  describe("SCTi.Focusable", function() {
+    it("should be defined", function() {
+      expect(SCTi.Focusable).toBeDefined();
+    });
+    
+    it("should respond to blur", function() {
+      var view = SCTi.Object.create(SCTi.Focusable),
+          wasCalled = false;
+
+      view.set('tiObject', {
+        blur: function() { wasCalled = true; }
+      });
+
+      view.blur();
+      expect(wasCalled).toEqual(true);
+    });
+
+    it("should respond to focus", function() {
+      var view = SCTi.Object.create(SCTi.Focusable),
+          wasCalled = false;
+
+      view.set('tiObject', {
+        focus: function() { wasCalled = true; }
+      });
+
+      view.focus();
+      expect(wasCalled).toEqual(true);
+    });
+  });
 })();

--- a/Resources/tests/view_test.js
+++ b/Resources/tests/view_test.js
@@ -58,6 +58,19 @@
       expect(fakeTiObject.add.callCount).toEqual(1);
     });
     
+    it("should be able to add childViews after render", function() {
+      var view = SCTi.View.create(),
+          childView = SCTi.View.create({backgroundColor: '#fff'});
+      
+      view.render();
+
+      view.add(childView);
+      
+      Ti.API.info(childView.get('tiObject'));
+      
+      expect(childView.get('tiObject')).toNotEqual(null);
+    });
+    
     it("should sync bindings before display", function() {
       var view = SCTi.View.create({
         content: SC.Object.create({value: "OHAI"}),

--- a/Resources/tests/view_test.js
+++ b/Resources/tests/view_test.js
@@ -60,13 +60,11 @@
     
     it("should be able to add childViews after render", function() {
       var view = SCTi.View.create(),
-          childView = SCTi.View.create({backgroundColor: '#fff'});
+          childView = SCTi.View.create();
       
       view.render();
 
       view.add(childView);
-      
-      Ti.API.info(childView.get('tiObject'));
       
       expect(childView.get('tiObject')).toNotEqual(null);
     });


### PR DESCRIPTION
### Biggest Change

Allow adding child views after the parent view is already rendered. Is there any reason we wouldn't do this? I know I'm going to need to be able add `MapAnnotations` to `MapViews` after the fact.
### The Rest

I had to rename the `focus` and `blur` events for `TextField` and `TextArea` so we can call `focus()` and `blur()` to show and hide the keyboard. I followed the `open:opened` naming with `focus:focused` and `blur:blurred`.

I also added the ability for `SCTi.Openable` objects to accept options on `open()`.

**All Tests Pass :)**
